### PR TITLE
Workaround for localhost

### DIFF
--- a/cfgmgr.py
+++ b/cfgmgr.py
@@ -88,17 +88,25 @@ class ConfigManager:
 
 
         # Post-process conf
-        # Replace localhost wiht 
-        self.boot['hosts'] =  { n:(h if h is not in ('localhost', '127.0.0.1') else socket.gethostname()) for n,h in self.boot['hosts'].items() }
-        # hosts = self.boot['hosts']
+        # Boot:
+        self.boot['hosts'] =  { n:(h if (h is not in ('localhost', '127.0.0.1')) else socket.gethostname()) for n,h in self.boot['hosts'].items() }
         
+        # Conf:
         ips = { n:socket.gethostbyname(h) for n,h in self.boot['hosts'].items()}
-        # Apply real name of hosts
+        # Set sender and receiver address to ips
         for c in json_extract(self.conf, 'sender_config')+json_extract(self.conf, 'receiver_config'):
             c['address'] = c['address'].format(**ips)
 
 
     def runtime_start(self, data: dict) -> dict:
+        """
+        Generates runtime start parameter set        
+        :param      data:  The data
+        :type       data:  dict
+        
+        :returns:   Complete parameter set.
+        :rtype:     dict
+        """
         start = copy.deepcopy(self.start)
 
         for c in json_extract(start, 'modules'):

--- a/cfgmgr.py
+++ b/cfgmgr.py
@@ -71,7 +71,9 @@ class ConfigManager:
                 except json.decoder.JSONDecodeError as e:
                     raise RuntimeError(f"ERROR: failed to load {f}.json") from e
 
-        # Basic checks
+        # Consistency check.
+        # Note to self: some commands (pause/resume) are meant to be for some applications only
+        # This check needs to be softened then
         assert cfgs['boot']['apps'].keys() == cfgs['init']['apps'].keys()
         assert cfgs['boot']['apps'].keys() == cfgs['conf']['apps'].keys()
         assert cfgs['boot']['apps'].keys() == cfgs['start']['apps'].keys()
@@ -86,7 +88,10 @@ class ConfigManager:
 
 
         # Post-process conf
+        # Replace localhost wiht 
+        self.boot['hosts'] =  { n:(h if h is not in ('localhost', '127.0.0.1') else socket.gethostname()) for n,h in self.boot['hosts'].items() }
         # hosts = self.boot['hosts']
+        
         ips = { n:socket.gethostbyname(h) for n,h in self.boot['hosts'].items()}
         # Apply real name of hosts
         for c in json_extract(self.conf, 'sender_config')+json_extract(self.conf, 'receiver_config'):

--- a/nanorc.py
+++ b/nanorc.py
@@ -42,12 +42,12 @@ class NanoRC:
         table.add_column("alive", style="magenta")
         table.add_column("pings", style="magenta")
         table.add_column("last cmd", style="magenta")
-        table.add_column("last cmd ok", style="magenta")
+        table.add_column("last succ. cmd", style="magenta")
 
         for app, sup in self.apps.items():
             alive = sup.handle.proc.is_alive()
             ping = sup.commander.ping()
-            table.add_row(app, str(alive), str(ping), sup.handle.host, sup.last_sent_command, sup.last_ok_command)
+            table.add_row(app, sup.handle.host, str(alive), str(ping),  sup.last_sent_command, sup.last_ok_command)
         self.console.print(table)
 
     def boot(self) -> None:
@@ -137,7 +137,7 @@ def cli(ctx, cfg_dir):
     ctx.obj = rc
     
     def cleanup_rc():
-        console.log("Terminating RC")
+        console.log("Terminating RC before exiting")
         rc.terminate()
 
     ctx.call_on_close(cleanup_rc)    


### PR DESCRIPTION
Ssh to localhost on clusters with afs/nfs accounts is potentially troublesome.
This PR works around that problem by replacing localhost and 127.0.0.1 with the actual hostname in the `boot` data.
Ssh then uses the expanded name as ssh target.
