### PR TITLE
Improved processing of environment variables

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -173,7 +173,8 @@ It can be instructive to take a closer look at how we can tell nanorc to `boot` 
                 "CET_PLUGIN_PATH": "getenv",
                 "DUNEDAQ_SHARE_PATH": "getenv",
                 "LD_LIBRARY_PATH": "getenv",
-                "PATH": "getenv"
+                "PATH": "getenv",
+                "TRACE_FILE": "getenv:/tmp/trace_buffer_${HOSTNAME}_${USER}"
             },
             "cmd": [
                 "CMD_FAC=rest://localhost:${APP_PORT}",
@@ -194,5 +195,6 @@ It can be instructive to take a closer look at how we can tell nanorc to `boot` 
 
 It should be pointed out that some substitutions are made when nanorc uses a file such as this to boot the processes. Specifically:
 
-* `"getenv"` is replaced with the actual value of the environment variable
+* `"getenv"` is replaced with the actual value of the environment variable, throwing a Python exception if it is unset
+* `"getenv:<default value>"` is replaced with the actual value of the environment variable if it is set, with `<default value>` used if it is unset
 * If a host is provided as `localhost` or `127.0.0.1`, the result of the Python call `socket.gethostname` is used in its place

--- a/src/nanorc/sshpm.py
+++ b/src/nanorc/sshpm.py
@@ -164,7 +164,7 @@ class SSHProcessManager(object):
                 "APP_PORT": app_conf["port"],
                 "APP_WD": os.getcwd()
                 })
-            cmd=';'.join([ f"export {n}={v}" for n,v in app_vars.items()] + boot_info['exec'][app_conf['exec']]['cmd'])
+            cmd=';'.join([ f"export {n}=\"{v}\"" for n,v in app_vars.items()] + boot_info['exec'][app_conf['exec']]['cmd'])
 
             log_file = f'log_{app_name}_{app_conf["port"]}.txt'
 


### PR DESCRIPTION
Add double-quotes around exported environment variables to resolve Bash
warnings about parentheses.

Alter processing of getenv variables so that a default variable value
can be specified, and improve the error message that occurs when an
environment variable is requested that doesn't exist in the environment
and has no default.