### PR TITLE
Do not create a new instance of SSHProcessManager each time boot is called

### DIFF
--- a/src/nanorc/node.py
+++ b/src/nanorc/node.py
@@ -179,7 +179,8 @@ class SubsystemNode(NodeMixin):
     def boot(self) -> NoReturn:
         self.log.debug(f"Sending boot to {self.name}")
         try:
-            self.pm = SSHProcessManager(self.console)
+            if self.pm is None:
+                self.pm = SSHProcessManager(self.console)
             self.pm.boot(self.cfgmgr.boot)
         except Exception as e:
             self.console.print_exception()


### PR DESCRIPTION
This causes the second boot to fail and subsequent terminates to
hang indefinitely. Found and tested using
dfmodules/integtest/command_order_test.py.