### PR TITLE
Check for None when trying to initiate the logbook in core

### DIFF
--- a/src/nanorc/__main_timing__.py
+++ b/src/nanorc/__main_timing__.py
@@ -37,7 +37,7 @@ from .cli import *
 @click.option('--log-path', type=click.Path(exists=True), default=os.getcwd(), help='Where the logs should go (on localhost of applications)')
 @click.option('--timeout', type=int, default=60, help='Application commands timeout')
 @click.option('--cfg-dumpdir', type=click.Path(), default="./", help='Path where the config gets copied on start')
-@click.option('--kerberos/--no-kerberos', default=False, help='Whether you want to use kerberos for communicating between processes')
+@click.option('--kerberos/--no-kerberos', default=True, help='Whether you want to use kerberos for communicating between processes')
 @click.argument('cfg_dir', type=click.Path(exists=True))
 @click.pass_obj
 @click.pass_context

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -49,7 +49,7 @@ class NanoRC:
         self.logbook = None
         self.log_path = None
 
-        if logbook_type != 'file' and logbook_type != '':
+        if logbook_type != 'file' and logbook_type != None and logbook_type != '':
             try:
                 elisa_conf = json.load(open(logbook_type,'r'))
                 if elisa_conf.get(self.apparatus_id):


### PR DESCRIPTION
This can happen for the timing nanorc, which doesn't use logbooks.